### PR TITLE
feat: lockFileMaintenanceの間隔を他と合わせてautomergeする

### DIFF
--- a/default.json
+++ b/default.json
@@ -10,7 +10,6 @@
     ":autodetectPinVersions",
     ":prHourlyLimitNone",
     ":prConcurrentLimit20",
-    ":maintainLockFilesWeekly",
     "group:allNonMajor",
     "workarounds:all"
   ],
@@ -21,6 +20,11 @@
   "rangeStrategy": "bump",
   "platformCommit": true,
   "platformAutomerge": true,
+  "lockFileMaintenance": {
+    "enabled": true,
+    "automerge": true,
+    "schedule": ["before 3:00 am on the 1st and 15th day of the month"]
+  },
   "packageRules": [
     {
       "matchPackageNames": ["node"],


### PR DESCRIPTION
# Description
SSIA

# Reason
- lockFileMaintenanceが全体設定のautomerge: falseを引き継いでいて手動マージになっていて面倒
- lockFileMaintenanceが毎週なくてもいい

# Document URL
現状: https://docs.renovatebot.com/presets-default/#maintainlockfilesweekly
設定方法: https://github.com/renovatebot/renovate/blob/main/docs/usage/key-concepts/automerge.md#automerge-lock-file-maintenance