### PR TITLE
feat(renovate): include vitest org to test group

### DIFF
--- a/default.json
+++ b/default.json
@@ -62,7 +62,7 @@
     },
     {
       "extends": "packages:test",
-      "matchPackageNames": ["vitest"],
+      "matchPackagePatterns": ["vitest", "^@vitest/"],
       "groupName": "test packages",
       "automerge": true
     },


### PR DESCRIPTION
## Description

<!-- プルリクの内容説明 -->

`@vitest/`から始めるパッケージをtestグループに追加。

## Reason

<!-- なぜその変更を入れたいのか -->

Renovateのアップデートで`@vitest/coverage-c8`と`vitest`が別々で出されましたのでできれば一緒にしたいです。

## Document URL

<!-- 参考できるドキュメントのURL -->
