### PR TITLE
feat: disable automerge on major version

### DIFF
--- a/default.json
+++ b/default.json
@@ -20,6 +20,9 @@
   "rangeStrategy": "bump",
   "platformCommit": true,
   "platformAutomerge": true,
+  "major": {
+    "automerge": false
+  },
   "lockFileMaintenance": {
     "enabled": true,
     "automerge": true,


### PR DESCRIPTION
## Description

<!-- プルリクの内容説明 -->

Auto-mergeはMajorでenableすると危ないのでここでdisableにしておきます

## Reason

<!-- なぜその変更を入れたいのか -->

Next.js majorのrenovate PRがなぜかAuto-mergeになってます

https://github.com/justincase-jp/engage/pull/1216

## Document URL

<!-- 参考できるドキュメントのURL -->
