### PR TITLE
chore: npm:unpublishSafeを追加

### DIFF
--- a/default.json
+++ b/default.json
@@ -11,7 +11,8 @@
     ":prHourlyLimitNone",
     ":prConcurrentLimit20",
     "group:allNonMajor",
-    "workarounds:all"
+    "workarounds:all",
+    "npm:unpublishSafe"
   ],
   "labels": ["dependencies"],
   "node": {


### PR DESCRIPTION
## Description
npm packageは72時間以内だとunpuplishされる可能性があるので、Renovateの更新も待つ。
PRも出さないためには、[:prNotPending](https://docs.renovatebot.com/presets-default/#prnotpending) も指定しないとかも？
<!-- プルリクの内容説明 -->

## Reason

<!-- なぜその変更を入れたいのか -->

## Document URL
https://docs.npmjs.com/policies/unpublish
https://docs.renovatebot.com/presets-npm/#npmunpublishsafe

<!-- 参考できるドキュメントのURL -->
